### PR TITLE
feat: add handshake completion timeout to wpdaemon

### DIFF
--- a/crates/wpdaemon/src/connection.rs
+++ b/crates/wpdaemon/src/connection.rs
@@ -257,6 +257,28 @@ pub async fn handle_sdp_offer(
         Arc::clone(&peer_connection),
     );
 
+    // Handshake timeout task: close connection if DataChannel is not opened within 15s
+    let pc_timeout = Arc::clone(&peer_connection);
+    tokio::spawn(async move {
+        tokio::time::sleep(tokio::time::Duration::from_secs(15)).await;
+        let has_dc = CLIENT_REGISTRY
+            .read()
+            .unwrap()
+            .data_channels
+            .contains_key(&client_id);
+        if !has_dc {
+            warn!(
+                "Handshake timeout: Client {} failed to open DataChannel within 15s, closing connection",
+                client_id
+            );
+            let _ = pc_timeout.close().await;
+            CLIENT_REGISTRY
+                .write()
+                .unwrap()
+                .unregister_client(client_id);
+        }
+    });
+
     peer_connection.on_peer_connection_state_change(Box::new(
         move |state: RTCPeerConnectionState| {
             info!("Client {} PeerConnection state: {}", client_id, state);


### PR DESCRIPTION
## 概要 / Overview
WebRTC SDP Handshake 完了後に DataChannel が一定時間開かれない場合、自動的に PeerConnection を切断・解放するタイムアウト機能を追加しました。

## 目的 / Motivation
- **Half-Open Connection DoS 攻撃の防止**: 悪意のあるクライアントが SDP Offer/Answer のハンドシェイクのみを行い、DataChannel を確立せずに接続を保持し続けてメモリやソケットリソースを占有する攻撃を防ぎます。

## 実装内容 / Key Changes
- `connection.rs` 内の `handle_sdp_offer` にて、クライアント登録後に 15 秒の非同期タイマータスク（`tokio::spawn`）を発行。
- 15 秒経過時に該当クライアントの DataChannel が確立されていない場合、`PeerConnection` を `close()` し `CLIENT_REGISTRY` からアンレジストします。

## テスト方法 / Verification
- `cargo test --workspace`
- `cargo clippy --workspace`