### PR TITLE
feat: add datachannel packet rate limiting to wpdaemon

### DIFF
--- a/crates/wpdaemon/src/connection.rs
+++ b/crates/wpdaemon/src/connection.rs
@@ -355,6 +355,13 @@ pub async fn handle_sdp_offer(
         dc.on_message(Box::new(move |msg: DataChannelMessage| {
             let dc_inner = Arc::clone(&dc_msg);
             Box::pin(async move {
+                if !crate::rate_limit::DATACHANNEL_RATE_LIMITER.check_and_consume(client_id) {
+                    warn!(
+                        "DataChannel rate limit exceeded for client {}, dropping packet",
+                        client_id
+                    );
+                    return;
+                }
                 if let Ok(packet) = ProtocolPacket::decode(&msg.data) {
                     process_incoming_packet(client_id, my_node_id, &dc_inner, packet).await;
                 }

--- a/crates/wpdaemon/src/lib.rs
+++ b/crates/wpdaemon/src/lib.rs
@@ -20,5 +20,8 @@ pub mod stun;
 // Re-export commonly used types
 pub use broadcast::{AUDIO_BROADCAST, AudioMessage};
 pub use config::{CONFIGURATION, Configuration, DEFAULT_CONFIG_PATH};
-pub use rate_limit::{GLOBAL_RATE_LIMITER, RateLimiter, rate_limit_middleware};
+pub use rate_limit::{
+    DATACHANNEL_RATE_LIMITER, DataChannelRateLimiter, GLOBAL_RATE_LIMITER, RateLimiter,
+    rate_limit_middleware,
+};
 pub use registry::{CLIENT_REGISTRY, ClientRegistry, matches_address};

--- a/crates/wpdaemon/src/rate_limit.rs
+++ b/crates/wpdaemon/src/rate_limit.rs
@@ -112,6 +112,57 @@ pub async fn rate_limit_middleware(req: Request, next: Next) -> Response {
     next.run(req).await
 }
 
+/// DataChannel packet rate limiter (client_id -> TokenBucket).
+pub struct DataChannelRateLimiter {
+    refill_rate: f64,
+    max_tokens: f64,
+    buckets: Mutex<HashMap<u64, TokenBucket>>,
+}
+
+impl DataChannelRateLimiter {
+    pub fn new(refill_rate: f64, max_tokens: f64) -> Self {
+        Self {
+            refill_rate,
+            max_tokens,
+            buckets: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn check_and_consume(&self, client_id: u64) -> bool {
+        let now = Instant::now();
+        let mut buckets = self.buckets.lock().unwrap();
+
+        if buckets.len() > 2000 {
+            buckets.retain(|_, b| now.duration_since(b.last_update) < Duration::from_secs(60));
+        }
+
+        let bucket = buckets.entry(client_id).or_insert_with(|| TokenBucket {
+            tokens: self.max_tokens,
+            last_update: now,
+        });
+
+        let elapsed = now.duration_since(bucket.last_update).as_secs_f64();
+        bucket.tokens = (bucket.tokens + elapsed * self.refill_rate).min(self.max_tokens);
+        bucket.last_update = now;
+
+        if bucket.tokens >= 1.0 {
+            bucket.tokens -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn remove_client(&self, client_id: u64) {
+        let mut buckets = self.buckets.lock().unwrap();
+        buckets.remove(&client_id);
+    }
+}
+
+/// Global DataChannel rate limiter: 100 packets/sec, max burst of 200 packets.
+pub static DATACHANNEL_RATE_LIMITER: LazyLock<Arc<DataChannelRateLimiter>> =
+    LazyLock::new(|| Arc::new(DataChannelRateLimiter::new(100.0, 200.0)));
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -138,5 +189,18 @@ mod tests {
         );
         let ip = extract_ip(&headers, None);
         assert_eq!(ip, IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)));
+    }
+
+    #[test]
+    fn test_datachannel_rate_limiter() {
+        let limiter = DataChannelRateLimiter::new(1.0, 2.0);
+        let cid = 42u64;
+
+        assert!(limiter.check_and_consume(cid));
+        assert!(limiter.check_and_consume(cid));
+        assert!(!limiter.check_and_consume(cid));
+
+        limiter.remove_client(cid);
+        assert!(limiter.check_and_consume(cid));
     }
 }

--- a/crates/wpdaemon/src/registry.rs
+++ b/crates/wpdaemon/src/registry.rs
@@ -99,6 +99,7 @@ impl ClientRegistry {
         for speakers in self.room_speakers.values_mut() {
             speakers.remove(&client_id);
         }
+        crate::rate_limit::DATACHANNEL_RATE_LIMITER.remove_client(client_id);
     }
 
     /// Find client ID matching a given UserAddress (exact or prefix match per WPIP-02 Section 5).


### PR DESCRIPTION
## 概要 / Overview
DataChannel 経由で受信するパケットに対するクライアント単位のレート制限機能（Token Bucket アルゴリズム）を追加しました。

## 目的 / Motivation
- **DataChannel Message Flood の防止**: DataChannel 確立後に秒間数万パケットのデータや連打パケットを流し込み、音声ブロードキャスト処理や CPU を高負荷にする DoS 攻撃を防止します。

## 実装内容 / Key Changes
- `rate_limit.rs` に `DataChannelRateLimiter` 構造体を追加（デフォルト: 秒間 100 パケット / バースト上限 200 パケット）。
- `connection.rs` の `on_message` ハンドラにて受信ごとにレート制限チェックを実施し、超過パケットをドロップ。
- クライアント切断（`unregister_client`）時にレート制限状態を自動クリーンアップ。

## テスト方法 / Verification
- `cargo test -p wpdaemon` (`test_datachannel_rate_limiter` 追加)