### PR TITLE
feat: add STUN UDP rate limiting and early drop to wpdaemon

### DIFF
--- a/crates/wpdaemon/src/stun.rs
+++ b/crates/wpdaemon/src/stun.rs
@@ -3,9 +3,15 @@
 //! This module implements a STUN (RFC 5389) and TURN media relay server
 //! running over UDP to facilitate NAT traversal for WebRTC clients.
 
+use crate::rate_limit::RateLimiter;
 use std::net::SocketAddr;
+use std::sync::{Arc, LazyLock};
 use tokio::net::UdpSocket;
-use tracing::{error, info, trace};
+use tracing::{error, info, trace, warn};
+
+/// Static STUN IP rate limiter: 20 requests/sec, max burst of 50.
+static STUN_RATE_LIMITER: LazyLock<Arc<RateLimiter>> =
+    LazyLock::new(|| Arc::new(RateLimiter::new(20.0, 50.0)));
 
 /// STUN Magic Cookie (RFC 5389)
 const STUN_MAGIC_COOKIE: u32 = 0x2112A442;
@@ -36,6 +42,14 @@ pub async fn run_stun_server(
 
         if len < 20 {
             continue; // Not a valid STUN header
+        }
+
+        if !STUN_RATE_LIMITER.check_and_consume(src.ip()) {
+            warn!(
+                "STUN packet rate limit exceeded for IP: {}, dropping",
+                src.ip()
+            );
+            continue;
         }
 
         let msg_type = u16::from_be_bytes([buf[0], buf[1]]);


### PR DESCRIPTION
## 概要 / Overview
STUN/TURN UDP サーバー（Port 3478）に対する IP 単位のパケットレート制限と Early Drop 機能を追加しました。

## 目的 / Motivation
- **UDP Flood & リフレクション（反射型 DDoS）攻撃の防止**: 大量の STUN Binding Request パケット送信による UDP ソケット過負荷や、応答の悪用を防ぎます。

## 実装内容 / Key Changes
- `stun.rs` に `STUN_RATE_LIMITER`（IP 単位: 秒間 20 リクエスト / バースト上限 50）を追加。
- `run_stun_server` の UDP 受信ループ冒頭で IP チェックを行い、上限超過パケットおよびヘッダー不正パケットを即座に破棄（Early Drop）。

## テスト方法 / Verification
- `cargo test -p wpdaemon`