### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale-issues-pullrequests.yml
+++ b/.github/workflows/stale-issues-pullrequests.yml
@@ -3,6 +3,11 @@ on:
   schedule:
     - cron: "30 1 * * *"
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   close-issues-and-pullrequests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/haruki7049/web-phone/security/code-scanning/3](https://github.com/haruki7049/web-phone/security/code-scanning/3)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` has only the scopes required by this job.  
Best fix without changing functionality: define permissions at the workflow root (applies to all jobs unless overridden), since there is only one job here.

For this file, add:

- `contents: read` (minimal repository read access)
- `issues: write` (needed to label/comment/close issues)
- `pull-requests: write` (needed to label/comment/close PRs)

Edit file `.github/workflows/stale-issues-pullrequests.yml`, immediately after the `on` block and before `jobs`.

No imports/dependencies/methods are needed (YAML config-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
