### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -3,6 +3,9 @@ name: Rust
 on:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   ci-on-Unix:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/haruki7049/web-phone/security/code-scanning/1](https://github.com/haruki7049/web-phone/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root so both jobs inherit least-privilege access.  
For this workflow, the best minimal setting is:

- `contents: read`

This preserves existing functionality (`actions/checkout` and read-only CI tasks) without granting unnecessary write scopes.

**File to change:** `.github/workflows/rust-ci.yml`  
**Region to change:** near the top-level keys, after `on:` and before `jobs:` (or equivalently before/after `name:` with valid YAML structure).  
No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
