### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -3,6 +3,9 @@ name: Rust
 on:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   ci-on-Unix:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/haruki7049/web-phone/security/code-scanning/2](https://github.com/haruki7049/web-phone/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root in `.github/workflows/rust-ci.yml`, right after the `on:` section (or before `jobs:`), so it applies to both `ci-on-Unix` and `ci-on-Windows`.

Best minimal fix without changing behavior:
- Set:
  - `contents: read`

Why this is the best fit:
- `actions/checkout` requires repository content read access.
- The shown jobs only build/test/check/clippy and do not create releases, comment on PRs, or write issues.
- A root-level permission avoids duplication and keeps both jobs consistently constrained.

No imports, methods, or dependencies are needed for YAML workflow changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
