### PR TITLE
Potential fix for code scanning alert no. 4: Disabled TLS certificate check

### DIFF
--- a/crates/wpapi/src/webrtc_session.rs
+++ b/crates/wpapi/src/webrtc_session.rs
@@ -568,9 +568,7 @@ pub async fn perform_sdp_handshake(
     let (_, auth_header_val) =
         crate::address::build_authorization_header(client_keypair, &local_desc.sdp);
 
-    let client = reqwest::Client::builder()
-        .danger_accept_invalid_certs(true)
-        .build()?;
+    let client = reqwest::Client::builder().build()?;
 
     let resp = client
         .post(&sdp_endpoint)


### PR DESCRIPTION
Potential fix for [https://github.com/haruki7049/web-phone/security/code-scanning/4](https://github.com/haruki7049/web-phone/security/code-scanning/4)

The fix is to stop disabling TLS certificate validation on the `reqwest` client. In `crates/wpapi/src/webrtc_session.rs`, replace the `reqwest::Client::builder().danger_accept_invalid_certs(true).build()?` sequence with a normal verified client build (or direct `reqwest::Client::new()`), which preserves existing functionality while restoring secure defaults.

Best single change (minimal, behavior-preserving):
- Edit the client construction near lines 571–573.
- Remove `.danger_accept_invalid_certs(true)`.
- Keep `.build()?` so error handling remains consistent with current code style.

No new methods, imports, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
