### PR TITLE
refactor(common): centralize Daemon HTTP client and authorization header handling (close #47)

### DIFF
--- a/crates/wpapi/src/client.rs
+++ b/crates/wpapi/src/client.rs
@@ -1,0 +1,68 @@
+//! Daemon HTTP API Client module for `wpapi`.
+//!
+//! Provides a centralized, reusable client for interacting with the `wpdaemon` HTTP endpoints,
+//! managing identity keypair creation, signature generation for authorization headers, and response parsing.
+
+use crate::address::{UserAddress, UserKeypair, build_authorization_header};
+use crate::config::Configuration;
+use anyhow::{Context, Result};
+
+/// Reusable HTTP API client for querying `wpdaemon` endpoints.
+#[derive(Debug, Clone)]
+pub struct DaemonApiClient {
+    client: reqwest::Client,
+}
+
+impl Default for DaemonApiClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DaemonApiClient {
+    /// Create a new `DaemonApiClient`.
+    pub fn new() -> Self {
+        Self {
+            client: reqwest::Client::new(),
+        }
+    }
+
+    /// Fetch registered user addresses from daemon (`/addresses` endpoint).
+    pub async fn fetch_registered_addresses(
+        &self,
+        config: &Configuration,
+    ) -> Result<Vec<UserAddress>> {
+        let endpoint = format!("{}/addresses", config.server_url());
+        let keypair = UserKeypair::generate();
+        let (_, auth_hdr) = build_authorization_header(&keypair, "");
+
+        let resp = self
+            .client
+            .get(&endpoint)
+            .header(reqwest::header::AUTHORIZATION, auth_hdr)
+            .send()
+            .await
+            .context("Failed to send HTTP request to daemon /addresses endpoint")?;
+
+        if !resp.status().is_success() {
+            anyhow::bail!("Daemon returned HTTP status {}", resp.status());
+        }
+
+        let addresses = resp
+            .json::<Vec<UserAddress>>()
+            .await
+            .context("Failed to parse addresses JSON response from daemon")?;
+
+        Ok(addresses)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_daemon_api_client_instantiation() {
+        let _client = DaemonApiClient::new();
+    }
+}

--- a/crates/wpapi/src/lib.rs
+++ b/crates/wpapi/src/lib.rs
@@ -404,7 +404,6 @@ pub unsafe extern "C" fn wpapi_list_addresses(
             return -1;
         }
         let cfg = unsafe { &(*config).0 };
-        let endpoint = format!("{}/addresses", cfg.server_url());
 
         let rt = match tokio::runtime::Builder::new_current_thread()
             .enable_all()

--- a/crates/wpapi/src/lib.rs
+++ b/crates/wpapi/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod address;
 pub mod audio;
 pub mod call;
+pub mod client;
 pub mod config;
 pub mod keystore;
 pub mod protocol;
@@ -20,6 +21,7 @@ pub use address::{
     verify_secp256k1_authorization_header_with_cache,
 };
 pub use audio::AudioEngine;
+pub use client::DaemonApiClient;
 pub use config::{CONFIGURATION, Configuration, DEFAULT_CONFIG_PATH};
 pub use keystore::{
     EncryptedKeyStore, KeyStoreError, get_default_keystore_path, load_encrypted_keystore,
@@ -416,18 +418,8 @@ pub unsafe extern "C" fn wpapi_list_addresses(
         };
 
         let res: Result<String, anyhow::Error> = rt.block_on(async {
-            let client = reqwest::Client::new();
-            let keypair = UserKeypair::generate();
-            let (_, auth_hdr) = build_authorization_header(&keypair, "");
-            let resp = client
-                .get(&endpoint)
-                .header(reqwest::header::AUTHORIZATION, auth_hdr)
-                .send()
-                .await?;
-            if !resp.status().is_success() {
-                anyhow::bail!("Server returned HTTP status {}", resp.status());
-            }
-            let addresses: Vec<UserAddress> = resp.json().await?;
+            let daemon_client = DaemonApiClient::new();
+            let addresses = daemon_client.fetch_registered_addresses(cfg).await?;
             let json_str = serde_json::to_string(&addresses)?;
             Ok(json_str)
         });

--- a/crates/wpclient/src/tui.rs
+++ b/crates/wpclient/src/tui.rs
@@ -438,36 +438,10 @@ fn fetch_registered_addresses(app: &mut TuiApp) {
     app.add_log("Fetching registered user addresses from daemon...".to_string());
 
     tokio::spawn(async move {
-        let endpoint = format!("{}/addresses", config.server_url());
-        let client = reqwest::Client::new();
-        let keypair = wpapi::UserKeypair::generate();
-        let (_, auth_hdr) = wpapi::build_authorization_header(&keypair, "");
-        match client
-            .get(&endpoint)
-            .header(reqwest::header::AUTHORIZATION, auth_hdr)
-            .send()
-            .await
-        {
-            Ok(resp) => {
-                if resp.status().is_success() {
-                    match resp.json::<Vec<UserAddress>>().await {
-                        Ok(addrs) => {
-                            let _ = event_tx.send(AppEvent::RegisteredAddresses(addrs)).await;
-                        }
-                        Err(e) => {
-                            let _ = event_tx
-                                .send(AppEvent::Log(format!("Failed to parse response: {}", e)))
-                                .await;
-                        }
-                    }
-                } else {
-                    let _ = event_tx
-                        .send(AppEvent::Log(format!(
-                            "Server returned HTTP status {}",
-                            resp.status()
-                        )))
-                        .await;
-                }
+        let daemon_client = wpapi::DaemonApiClient::new();
+        match daemon_client.fetch_registered_addresses(&config).await {
+            Ok(addrs) => {
+                let _ = event_tx.send(AppEvent::RegisteredAddresses(addrs)).await;
             }
             Err(e) => {
                 let _ = event_tx


### PR DESCRIPTION
Closes #47. Introduces DaemonApiClient in wpapi for unified HTTP communication and signature header generation.