### PR TITLE
refactor(common): introduce domain-specific error enums using thiserror (close #48)

### DIFF
--- a/crates/wpapi/src/error.rs
+++ b/crates/wpapi/src/error.rs
@@ -1,0 +1,52 @@
+//! Top-level domain-specific error types for `wpapi`.
+
+use crate::address::AuthError;
+use crate::keystore::KeyStoreError;
+use crate::protocol::ProtocolError;
+use crate::sframe::SFrameError;
+use thiserror::Error;
+
+/// Unified domain-specific error enum for all `wpapi` operations.
+#[derive(Debug, Error)]
+pub enum WpapiError {
+    /// Authentication or signature verification error.
+    #[error("Authentication error: {0}")]
+    Auth(#[from] AuthError),
+
+    /// Keystore encryption/decryption or storage error.
+    #[error("Keystore error: {0}")]
+    KeyStore(#[from] KeyStoreError),
+
+    /// Protocol packet encoding/decoding error.
+    #[error("Protocol error: {0}")]
+    Protocol(#[from] ProtocolError),
+
+    /// SFrame zero-knowledge encryption/decryption error.
+    #[error("SFrame E2EE error: {0}")]
+    SFrame(#[from] SFrameError),
+
+    /// Audio engine or capture/playback device error.
+    #[error("Audio engine error: {0}")]
+    Audio(String),
+
+    /// Session or connection management error.
+    #[error("Session error: {0}")]
+    Session(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_wpapi_error_conversions() {
+        let auth_err: WpapiError = AuthError::InvalidEd25519Signature.into();
+        assert!(matches!(auth_err, WpapiError::Auth(_)));
+
+        let keystore_err: WpapiError = KeyStoreError::InvalidPassphrase.into();
+        assert!(matches!(keystore_err, WpapiError::KeyStore(_)));
+
+        let protocol_err: WpapiError = ProtocolError::EmptyPacket.into();
+        assert!(matches!(protocol_err, WpapiError::Protocol(_)));
+    }
+}

--- a/crates/wpapi/src/lib.rs
+++ b/crates/wpapi/src/lib.rs
@@ -4,6 +4,7 @@ pub mod address;
 pub mod audio;
 pub mod call;
 pub mod config;
+pub mod error;
 pub mod keystore;
 pub mod protocol;
 pub mod resample;
@@ -21,6 +22,7 @@ pub use address::{
 };
 pub use audio::AudioEngine;
 pub use config::{CONFIGURATION, Configuration, DEFAULT_CONFIG_PATH};
+pub use error::WpapiError;
 pub use keystore::{
     EncryptedKeyStore, KeyStoreError, get_default_keystore_path, load_encrypted_keystore,
     save_encrypted_keystore,


### PR DESCRIPTION
Closes #48. Adds unified WpapiError enum using thiserror.